### PR TITLE
dereference symlinks in copy

### DIFF
--- a/lib/phoenix_copy.ex
+++ b/lib/phoenix_copy.ex
@@ -51,7 +51,12 @@ defmodule Phoenix.Copy do
     source = Keyword.fetch!(config, :source)
     destination = Keyword.fetch!(config, :destination)
 
-    File.cp_r!(source, destination, dereference_symlinks: true)
+    # TODO: Remove check when support for Elixir < 1.14 is removed.
+    if Version.match?(System.version(), ">= 1.14.0-rc.0") do
+      File.cp_r!(source, destination, dereference_symlinks: true)
+    else
+      File.cp_r!(source, destination)
+    end
   end
 
   def run(profiles) when is_list(profiles) do

--- a/lib/phoenix_copy.ex
+++ b/lib/phoenix_copy.ex
@@ -51,7 +51,7 @@ defmodule Phoenix.Copy do
     source = Keyword.fetch!(config, :source)
     destination = Keyword.fetch!(config, :destination)
 
-    File.cp_r!(source, destination)
+    File.cp_r!(source, destination, dereference_symlinks: true)
   end
 
   def run(profiles) when is_list(profiles) do


### PR DESCRIPTION
phx_copy is a build step; so I think symlinks shall be de-referenced. In my usage model, I want to skip the esbuild step and just symlink the phoenix.js from `deps` into `assets`, and let phx_copy take care of the rest.